### PR TITLE
feat: timeouts and cli interface

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,4 +26,5 @@ COPY --from=builder /workspace/main .
 COPY --from=builder /bin/grpc_health_probe ./grpc_health_probe
 USER 65532:65532
 
-ENTRYPOINT ["/main", "run"]
+ENTRYPOINT ["/main"]
+CMD ["run"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,10 @@ COPY go.sum .
 # and so that source changes don't invalidate our downloaded layer
 RUN go mod download
 COPY server/ ./server
+COPY cmd/ ./cmd
+COPY main.go ./main.go
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o main server/main.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o main main.go
 
 # Use distroless as minimal base image
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
@@ -24,4 +26,4 @@ COPY --from=builder /workspace/main .
 COPY --from=builder /bin/grpc_health_probe ./grpc_health_probe
 USER 65532:65532
 
-ENTRYPOINT ["/main"]
+ENTRYPOINT ["/main", "run"]

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ PRs that don't match that branch schema will be rejected, maybe with a reminder.
 One can also develop without the full Kubernetes flow by doing the following to get a normal local Go workflow: 
 1. Run the server, run the following from the project root **after** setting environment variables for your database config
 ```
-go run server/main.go
+go run main.go run
 ```
 2. Run the client, each run will make one request
 ```

--- a/README.md
+++ b/README.md
@@ -64,6 +64,20 @@ When workers "complete" a task, they submit it with an optional next task. This 
 
 This allows simple and complicated workflows, alongside workers dedicated to each phase of a workflow. This should also allow highly horizontally scalable workloads using an appropriate datastore.
 
+### Flow Continued
+
+The above is a basic use case. However there are other features available that may not be required by most use cases.
+
+### Timeouts 
+
+When getting a task the auto target state is swapped with the current state, e.g. the current state becomes "submitted-working" by default. When getting a task, you can set also timeout. When a task times out the current and auto target states are swapped back so they can get picked up again.
+
+You may want a task to timeout after being submitted. In this case, as an example, you can submit a task with a timeout and a "dead" state as it's auto target state. When getting a task you can then override the current and auto target states to move the task forward to state "B" with auto target "dead B".
+
+A timeout does *not* happen automatically. You control when your timeout checks happen, using a `CleanUpTimedOutRequest`. It uses `at_time` to compare tasks against to see if they're timed out, and optionaly a `queue` to limit which tasks this affects. This has the added benefit of letting you time out tasks early or late in testing and such.
+
+Corndogs does provide some helper utilities for timeouts. There is a `timeout` command provided in the cli that will send a request at the current time using the address, port, and optional queue flags. There is also a simple cronjob provided by [the corndogs chart](https://github.com/TnLCommunity/chart-corndogs).
+
 ## Supported datastores
 
 Current targets are Postgres and room for others unplanned. The design is such that Corndogs should not know where it's storing things except in the Store implementation, it just gets pointed to a URL and picks up where it needs to. This is Cloud Native.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,0 +1,32 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+// rootCmd represents the base command when called without any subcommands
+var rootCmd = NewRootCommand()
+
+func NewRootCommand() *cobra.Command {
+	rootCmd := &cobra.Command{
+		Use:   "",
+		Short: "The corndogs cli",
+		Long:  "The corndogs cli. See available commands below.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return fmt.Errorf("This is the root command. It doesnt do anything without a subcommand listed below.")
+		},
+	}
+	return rootCmd
+}
+
+// Execute adds all child commands to the root command and sets flags appropriately.
+// This is called by main.main(). It only needs to happen once to the rootCmd.
+func Execute() {
+	err := rootCmd.Execute()
+	if err != nil {
+		os.Exit(1)
+	}
+}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -1,0 +1,22 @@
+package cmd
+
+import (
+	"github.com/TnLCommunity/corndogs/server"
+	"github.com/spf13/cobra"
+)
+
+var runCmd = NewRunCommand()
+
+func NewRunCommand() *cobra.Command {
+	runCmd := &cobra.Command{
+		Use:   "run",
+		Short: "Run the corndogs service",
+		Long:  "Run the corndogs service",
+		Run: func(cmd *cobra.Command, args []string) {
+			server.SetupAndRun()
+		},
+	}
+
+	rootCmd.AddCommand(runCmd)
+	return runCmd
+}

--- a/cmd/timeout.go
+++ b/cmd/timeout.go
@@ -1,0 +1,58 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	corndogsv1alpha1 "github.com/TnLCommunity/protos-corndogs/gen/proto/go/corndogs/v1alpha1"
+	"github.com/spf13/cobra"
+	"google.golang.org/grpc"
+)
+
+var timeoutCommand = NewTimeoutCommand()
+
+func NewTimeoutCommand() *cobra.Command {
+	var address string
+	var port string
+	timeoutCommand := &cobra.Command{
+		Use:   "timeout",
+		Short: "Send a CleanUpTimedOut request at the current time to a corndogs service",
+		Long:  "Send a CleanUpTimedOut request at the current time to a corndogs service",
+		Run: func(cmd *cobra.Command, args []string) {
+			SendCleanUpTimedOut(address, port)
+		},
+	}
+
+	timeoutCommand.Flags().StringVarP(&address, "address", "a", "127.0.0.1", "The address to connect to the corndogs service")
+	timeoutCommand.Flags().StringVarP(&port, "port", "p", "5080", "The port to connect to the corndogs service")
+	rootCmd.AddCommand(timeoutCommand)
+	return timeoutCommand
+}
+
+func SendCleanUpTimedOut(address, port string) {
+
+	// connect
+	connectTo := fmt.Sprintf("%s:%s", address, port)
+	fmt.Println("Connecting to:", connectTo)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	conn, err := grpc.DialContext(ctx, connectTo, grpc.WithInsecure())
+	if err != nil {
+		panic(err)
+	}
+	cancel()
+	corndogsClient := corndogsv1alpha1.NewCorndogsServiceClient(conn)
+	fmt.Println("Connected")
+
+	nowUTC := time.Now().Add(time.Duration(7) * time.Second).UTC()
+	fmt.Println("Sending at time:", nowUTC)
+	timeToTimeout := nowUTC.UnixNano()
+	cleanUpTimedOutRequest := &corndogsv1alpha1.CleanUpTimedOutRequest{
+		AtTime: timeToTimeout,
+	}
+	cleanUpTimedOutResponse, err := corndogsClient.CleanUpTimedOut(context.Background(), cleanUpTimedOutRequest)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("Timed out: %d\n", cleanUpTimedOutResponse.TimedOut)
+}

--- a/cmd/timeout.go
+++ b/cmd/timeout.go
@@ -33,7 +33,6 @@ func NewTimeoutCommand() *cobra.Command {
 }
 
 func SendCleanUpTimedOut(address, port, queue string) {
-
 	// connect
 	connectTo := fmt.Sprintf("%s:%s", address, port)
 	fmt.Println("Connecting to:", connectTo)
@@ -47,7 +46,12 @@ func SendCleanUpTimedOut(address, port, queue string) {
 	fmt.Println("Connected")
 
 	nowUTC := time.Now().Add(time.Duration(7) * time.Second).UTC()
-	fmt.Println("Sending at time:", nowUTC)
+
+	if queue != "" {
+		fmt.Printf("Sending for queue '%s' at time: %s\n", queue, nowUTC)
+	} else {
+		fmt.Println("Sending at time:", nowUTC)
+	}
 	timeToTimeout := nowUTC.UnixNano()
 	cleanUpTimedOutRequest := &corndogsv1alpha1.CleanUpTimedOutRequest{
 		AtTime: timeToTimeout,

--- a/cmd/timeout.go
+++ b/cmd/timeout.go
@@ -15,22 +15,24 @@ var timeoutCommand = NewTimeoutCommand()
 func NewTimeoutCommand() *cobra.Command {
 	var address string
 	var port string
+	var queue string
 	timeoutCommand := &cobra.Command{
 		Use:   "timeout",
 		Short: "Send a CleanUpTimedOut request at the current time to a corndogs service",
 		Long:  "Send a CleanUpTimedOut request at the current time to a corndogs service",
 		Run: func(cmd *cobra.Command, args []string) {
-			SendCleanUpTimedOut(address, port)
+			SendCleanUpTimedOut(address, port, queue)
 		},
 	}
 
 	timeoutCommand.Flags().StringVarP(&address, "address", "a", "127.0.0.1", "The address to connect to the corndogs service")
 	timeoutCommand.Flags().StringVarP(&port, "port", "p", "5080", "The port to connect to the corndogs service")
+	timeoutCommand.Flags().StringVarP(&queue, "queue", "q", "", "The queue to limit the timeout to. If left blank the timeout will affect all tasks.")
 	rootCmd.AddCommand(timeoutCommand)
 	return timeoutCommand
 }
 
-func SendCleanUpTimedOut(address, port string) {
+func SendCleanUpTimedOut(address, port, queue string) {
 
 	// connect
 	connectTo := fmt.Sprintf("%s:%s", address, port)
@@ -49,6 +51,7 @@ func SendCleanUpTimedOut(address, port string) {
 	timeToTimeout := nowUTC.UnixNano()
 	cleanUpTimedOutRequest := &corndogsv1alpha1.CleanUpTimedOutRequest{
 		AtTime: timeToTimeout,
+		Queue:  queue,
 	}
 	cleanUpTimedOutResponse, err := corndogsClient.CleanUpTimedOut(context.Background(), cleanUpTimedOutRequest)
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/TnLCommunity/corndogs
 go 1.17
 
 require (
-	github.com/TnLCommunity/protos-corndogs v1.0.1
+	github.com/TnLCommunity/protos-corndogs v1.1.1
 	github.com/brianvoe/gofakeit/v6 v6.11.0
 	github.com/google/uuid v1.3.0
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/TnLCommunity/corndogs
 go 1.17
 
 require (
-	github.com/TnLCommunity/protos-corndogs v1.1.1
+	github.com/TnLCommunity/protos-corndogs v1.1.2
 	github.com/brianvoe/gofakeit/v6 v6.11.0
 	github.com/google/uuid v1.3.0
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
 	github.com/pressly/goose/v3 v3.5.0
 	github.com/rs/zerolog v1.26.1
+	github.com/spf13/cobra v1.0.0
 	github.com/stretchr/testify v1.7.0
 	google.golang.org/grpc v1.43.0
 	google.golang.org/protobuf v1.27.1
@@ -21,6 +22,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.1.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/golang/protobuf v1.5.0 // indirect
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/jackc/chunkreader/v2 v2.0.1 // indirect
 	github.com/jackc/pgconn v1.10.1 // indirect
 	github.com/jackc/pgio v1.0.0 // indirect
@@ -37,6 +39,7 @@ require (
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.26.0 // indirect
 	github.com/prometheus/procfs v0.6.0 // indirect
+	github.com/spf13/pflag v1.0.3 // indirect
 	golang.org/x/crypto v0.0.0-20211215165025-cf75a172585e // indirect
 	golang.org/x/net v0.0.0-20211015210444-4f30a5c0130f // indirect
 	golang.org/x/text v0.3.7 // indirect

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/TnLCommunity/corndogs
 go 1.17
 
 require (
-	github.com/TnLCommunity/protos-corndogs v1.1.2
+	github.com/TnLCommunity/protos-corndogs v1.1.3
 	github.com/brianvoe/gofakeit/v6 v6.11.0
 	github.com/google/uuid v1.3.0
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0
 github.com/Microsoft/go-winio v0.5.0/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOpzfwIujj1a84=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5/go.mod h1:lmUJ/7eu/Q8D7ML55dXQrVaamCz2vxCfdQBasLZfHKk=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
-github.com/TnLCommunity/protos-corndogs v1.1.2 h1:8COAB/gN3nJSfVdGPAm/0Z+d+onOVw4SMpp425WIbsA=
-github.com/TnLCommunity/protos-corndogs v1.1.2/go.mod h1:eM4NFoTquavJfOI2156jVY1IPPCM23LfmVWNqC3ALaM=
+github.com/TnLCommunity/protos-corndogs v1.1.3 h1:z5K2Lfn/f2CgRi6g6iPLmBBeAI1KAxXkLgSWzUH5q0I=
+github.com/TnLCommunity/protos-corndogs v1.1.3/go.mod h1:eM4NFoTquavJfOI2156jVY1IPPCM23LfmVWNqC3ALaM=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0
 github.com/Microsoft/go-winio v0.5.0/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOpzfwIujj1a84=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5/go.mod h1:lmUJ/7eu/Q8D7ML55dXQrVaamCz2vxCfdQBasLZfHKk=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
-github.com/TnLCommunity/protos-corndogs v1.1.1 h1:LsufWNryICYuiyuBct06zVfxq7EHI5MJyUlLWJLS2GU=
-github.com/TnLCommunity/protos-corndogs v1.1.1/go.mod h1:eM4NFoTquavJfOI2156jVY1IPPCM23LfmVWNqC3ALaM=
+github.com/TnLCommunity/protos-corndogs v1.1.2 h1:8COAB/gN3nJSfVdGPAm/0Z+d+onOVw4SMpp425WIbsA=
+github.com/TnLCommunity/protos-corndogs v1.1.2/go.mod h1:eM4NFoTquavJfOI2156jVY1IPPCM23LfmVWNqC3ALaM=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=

--- a/go.sum
+++ b/go.sum
@@ -140,6 +140,7 @@ github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
+github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/jackc/chunkreader v1.0.0 h1:4s39bBR8ByfqH+DKm8rQA3E1LHZWB9XWcrz8fqaZbe0=
 github.com/jackc/chunkreader v1.0.0/go.mod h1:RT6O25fNZIuasFJRyZ4R/Y2BbhasbmZXF9QQ7T3kePo=
@@ -322,8 +323,10 @@ github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4k
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
+github.com/spf13/cobra v1.0.0 h1:6m/oheQuQ13N9ks4hubMG6BnvwOeaJrqSPLahSnczz8=
 github.com/spf13/cobra v1.0.0/go.mod h1:/6GTrnGXV9HjY+aR4k0oJ5tcvakLuG6EuKReYlHNrgE=
 github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
+github.com/spf13/pflag v1.0.3 h1:zPAT6CGy6wXeQ7NtTnaTerfKOsV6V6F8agHXFiazDkg=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/viper v1.4.0/go.mod h1:PTJ7Z/lr49W6bUbkmS1V3by4uWynFiR9p7+dSq/yZzE=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0
 github.com/Microsoft/go-winio v0.5.0/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOpzfwIujj1a84=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5/go.mod h1:lmUJ/7eu/Q8D7ML55dXQrVaamCz2vxCfdQBasLZfHKk=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
-github.com/TnLCommunity/protos-corndogs v1.0.1 h1:SOUCr81xWvEHq0PpX5DMzk1fkzaOoNCfUm+njaFjK5o=
-github.com/TnLCommunity/protos-corndogs v1.0.1/go.mod h1:eM4NFoTquavJfOI2156jVY1IPPCM23LfmVWNqC3ALaM=
+github.com/TnLCommunity/protos-corndogs v1.1.1 h1:LsufWNryICYuiyuBct06zVfxq7EHI5MJyUlLWJLS2GU=
+github.com/TnLCommunity/protos-corndogs v1.1.1/go.mod h1:eM4NFoTquavJfOI2156jVY1IPPCM23LfmVWNqC3ALaM=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=

--- a/main.go
+++ b/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/TnLCommunity/corndogs/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -11,6 +11,7 @@ var PrometheusEnabled = GetEnvAsBoolOrDefault("PROMETHEUS_ENABLED", "false")
 var DefaultQueue = GetEnvOrDefault("DEFAULT_QUEUE", "default")
 var DefaultStartingState = GetEnvOrDefault("DEFAULT_STARTING_STATE", "submitted")
 var DefaultTimeout = int64(GetEnvAsIntOrDefault("DEFAULT_TIMEOUT", "0"))
+var DefaultWorkingSuffix = "-working"
 var RequestIdHeader = GetEnvOrDefault("REQUEST_ID_HEADER", "X-Request-ID")
 
 func GetEnvOrDefault(env, defaultValue string) string {

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -10,6 +10,7 @@ var FlushBytes = int64(GetEnvAsIntOrDefault("FLUSH_BYTES", "1000"))
 var PrometheusEnabled = GetEnvAsBoolOrDefault("PROMETHEUS_ENABLED", "false")
 var DefaultQueue = GetEnvOrDefault("DEFAULT_QUEUE", "default")
 var DefaultStartingState = GetEnvOrDefault("DEFAULT_STARTING_STATE", "submitted")
+var DefaultTimeout = int64(GetEnvAsIntOrDefault("DEFAULT_TIMEOUT", "0"))
 var RequestIdHeader = GetEnvOrDefault("REQUEST_ID_HEADER", "X-Request-ID")
 
 func GetEnvOrDefault(env, defaultValue string) string {

--- a/server/implementations/gettasks.go
+++ b/server/implementations/gettasks.go
@@ -20,12 +20,6 @@ func (s *V1Alpha1Server) GetNextTask(ctx context.Context, req *corndogsv1alpha1.
 	if req.CurrentState == "" {
 		req.CurrentState = config.DefaultStartingState
 	}
-	if req.Timeout == 0 {
-		req.Timeout = config.DefaultTimeout
-	}
-	if req.Timeout < 0 {
-		req.Timeout = 0
-	}
 	response, nil := store.AppStore.GetNextTask(req)
 	return response, nil
 }

--- a/server/implementations/gettasks.go
+++ b/server/implementations/gettasks.go
@@ -14,7 +14,12 @@ func (s *V1Alpha1Server) MustGetTaskStateByID(ctx context.Context, req *corndogs
 }
 
 func (s *V1Alpha1Server) GetNextTask(ctx context.Context, req *corndogsv1alpha1.GetNextTaskRequest) (*corndogsv1alpha1.GetNextTaskResponse, error) {
-
+	if req.Queue == "" {
+		req.Queue = config.DefaultQueue
+	}
+	if req.CurrentState == "" {
+		req.CurrentState = config.DefaultStartingState
+	}
 	if req.Timeout == 0 {
 		req.Timeout = config.DefaultTimeout
 	}

--- a/server/implementations/gettasks.go
+++ b/server/implementations/gettasks.go
@@ -3,6 +3,7 @@ package implementations
 import (
 	"context"
 
+	"github.com/TnLCommunity/corndogs/server/config"
 	"github.com/TnLCommunity/corndogs/server/store"
 	corndogsv1alpha1 "github.com/TnLCommunity/protos-corndogs/gen/proto/go/corndogs/v1alpha1"
 )
@@ -13,6 +14,13 @@ func (s *V1Alpha1Server) MustGetTaskStateByID(ctx context.Context, req *corndogs
 }
 
 func (s *V1Alpha1Server) GetNextTask(ctx context.Context, req *corndogsv1alpha1.GetNextTaskRequest) (*corndogsv1alpha1.GetNextTaskResponse, error) {
+
+	if req.Timeout == 0 {
+		req.Timeout = config.DefaultTimeout
+	}
+	if req.Timeout < 0 {
+		req.Timeout = 0
+	}
 	response, nil := store.AppStore.GetNextTask(req)
 	return response, nil
 }

--- a/server/implementations/modifytasks.go
+++ b/server/implementations/modifytasks.go
@@ -21,3 +21,8 @@ func (s *V1Alpha1Server) CancelTask(ctx context.Context, req *corndogsv1alpha1.C
 	response, nil := store.AppStore.CancelTask(req)
 	return response, nil
 }
+
+func (s *V1Alpha1Server) CleanUpTimedOut(ctx context.Context, req *corndogsv1alpha1.CleanUpTimedOutRequest) (*corndogsv1alpha1.CleanUpTimedOutResponse, error) {
+	response, nil := store.AppStore.CleanUpTimedOut(req)
+	return nil, nil
+}

--- a/server/implementations/modifytasks.go
+++ b/server/implementations/modifytasks.go
@@ -24,5 +24,5 @@ func (s *V1Alpha1Server) CancelTask(ctx context.Context, req *corndogsv1alpha1.C
 
 func (s *V1Alpha1Server) CleanUpTimedOut(ctx context.Context, req *corndogsv1alpha1.CleanUpTimedOutRequest) (*corndogsv1alpha1.CleanUpTimedOutResponse, error) {
 	response, nil := store.AppStore.CleanUpTimedOut(req)
-	return nil, nil
+	return response, nil
 }

--- a/server/implementations/modifytasks.go
+++ b/server/implementations/modifytasks.go
@@ -3,11 +3,21 @@ package implementations
 import (
 	"context"
 
+	"github.com/TnLCommunity/corndogs/server/config"
 	"github.com/TnLCommunity/corndogs/server/store"
 	corndogsv1alpha1 "github.com/TnLCommunity/protos-corndogs/gen/proto/go/corndogs/v1alpha1"
 )
 
 func (s *V1Alpha1Server) UpdateTask(ctx context.Context, req *corndogsv1alpha1.UpdateTaskRequest) (*corndogsv1alpha1.UpdateTaskResponse, error) {
+	if req.CurrentState == "" {
+		req.CurrentState = config.DefaultStartingState
+	}
+	if req.NewState == "" {
+		req.NewState = "updated"
+	}
+	if req.AutoTargetState == "" {
+		req.AutoTargetState = req.NewState + config.DefaultWorkingSuffix
+	}
 	response, nil := store.AppStore.UpdateTask(req)
 	return response, nil
 }

--- a/server/implementations/submittask.go
+++ b/server/implementations/submittask.go
@@ -9,6 +9,16 @@ import (
 )
 
 func (s *V1Alpha1Server) SubmitTask(ctx context.Context, req *corndogsv1alpha1.SubmitTaskRequest) (*corndogsv1alpha1.SubmitTaskResponse, error) {
+	if req.Queue == "" {
+		req.Queue = config.DefaultQueue
+	}
+	if req.CurrentState == "" {
+		req.CurrentState = config.DefaultStartingState
+	}
+	if req.AutoTargetState == "" {
+		req.AutoTargetState = req.CurrentState + config.DefaultWorkingSuffix
+	}
+
 	// Since protobuf default int values are 0, if they wanted 0, they have to send a negative value
 	// which is otherwise invalid as a timeout
 	if req.Timeout == 0 {

--- a/server/implementations/submittask.go
+++ b/server/implementations/submittask.go
@@ -9,6 +9,8 @@ import (
 )
 
 func (s *V1Alpha1Server) SubmitTask(ctx context.Context, req *corndogsv1alpha1.SubmitTaskRequest) (*corndogsv1alpha1.SubmitTaskResponse, error) {
+	// Since protobuf default int values are 0, if they wanted 0, they have to send a negative value
+	// which is otherwise invalid as a timeout
 	if req.Timeout == 0 {
 		req.Timeout = config.DefaultTimeout
 	}

--- a/server/implementations/submittask.go
+++ b/server/implementations/submittask.go
@@ -3,11 +3,18 @@ package implementations
 import (
 	"context"
 
+	"github.com/TnLCommunity/corndogs/server/config"
 	"github.com/TnLCommunity/corndogs/server/store"
 	corndogsv1alpha1 "github.com/TnLCommunity/protos-corndogs/gen/proto/go/corndogs/v1alpha1"
 )
 
 func (s *V1Alpha1Server) SubmitTask(ctx context.Context, req *corndogsv1alpha1.SubmitTaskRequest) (*corndogsv1alpha1.SubmitTaskResponse, error) {
+	if req.Timeout == 0 {
+		req.Timeout = config.DefaultTimeout
+	}
+	if req.Timeout < 0 {
+		req.Timeout = 0
+	}
 	response, nil := store.AppStore.SubmitTask(req)
 	return response, nil
 }

--- a/server/server.go
+++ b/server/server.go
@@ -1,4 +1,4 @@
-package main
+package server
 
 import (
 	"fmt"
@@ -25,7 +25,7 @@ import (
 	"google.golang.org/grpc"
 )
 
-func main() {
+func SetupAndRun() {
 	// get logging setup
 	logging.InitLogging()
 	// use the postgres store

--- a/server/store/postgresstore/postgresstore.go
+++ b/server/store/postgresstore/postgresstore.go
@@ -182,7 +182,19 @@ func (s PostgresStore) GetNextTask(req *corndogsv1alpha1.GetNextTaskRequest) (*c
 		// swap states so if a timeout occurs we set them back to what they were
 		model.CurrentState = model.AutoTargetState
 		model.AutoTargetState = req.CurrentState
-		model.Timeout = req.Timeout
+
+		if req.OverrideCurrentState != "" {
+			model.CurrentState = req.OverrideCurrentState
+		}
+		if req.OverrideAutoTargetState != "" {
+			model.AutoTargetState = req.OverrideAutoTargetState
+		}
+		if req.OverrideTimeout < 0 {
+			model.Timeout = 0
+		} else if req.OverrideTimeout != 0 {
+			model.Timeout = req.OverrideTimeout
+		}
+
 		result = DB.Save(model)
 		if result.Error != nil {
 			if errors.Is(result.Error, gorm.ErrRecordNotFound) || result.RowsAffected == 0 {

--- a/server/store/postgresstore/postgresstore.go
+++ b/server/store/postgresstore/postgresstore.go
@@ -125,12 +125,6 @@ func (s PostgresStore) MustGetTaskStateByID(req *corndogsv1alpha1.GetTaskStateBy
 func (s PostgresStore) GetNextTask(req *corndogsv1alpha1.GetNextTaskRequest) (*corndogsv1alpha1.GetNextTaskResponse, error) {
 	// TODO: This may be something that can be simplified, determine that and do so or explain why it can't
 	taskProto := &corndogsv1alpha1.Task{}
-	if req.Queue == "" {
-		req.Queue = config.DefaultQueue
-	}
-	if req.CurrentState == "" {
-		req.CurrentState = config.DefaultStartingState
-	}
 	err := DB.Transaction(func(tx *gorm.DB) error {
 		model := models.Task{}
 		var nextUuid string

--- a/server/store/postgresstore/postgresstore.go
+++ b/server/store/postgresstore/postgresstore.go
@@ -337,10 +337,11 @@ func (s PostgresStore) CleanUpTimedOut(req *corndogsv1alpha1.CleanUpTimedOutRequ
 	var count int64 = 0
 	err := DB.Transaction(func(tx *gorm.DB) error {
 		model := models.Task{}
-		result := DB.Model(model).Where("(update_time + (timeout * ?)) < ?", time.Second.Nanoseconds(), req.AtTime).Updates(
+		result := DB.Model(model).Where("timeout > 0 AND (update_time + (timeout * ?)) < ?", time.Second.Nanoseconds(), req.AtTime).Updates(
 			map[string]interface{}{
 				"current_state":     gorm.Expr("auto_target_state"),
 				"auto_target_state": gorm.Expr("current_state"),
+				"timeout":           0,
 			})
 		if result.Error != nil {
 			if errors.Is(result.Error, gorm.ErrRecordNotFound) {

--- a/server/store/postgresstore/postgresstore.go
+++ b/server/store/postgresstore/postgresstore.go
@@ -212,15 +212,6 @@ func (s PostgresStore) GetNextTask(req *corndogsv1alpha1.GetNextTaskRequest) (*c
 
 func (s PostgresStore) UpdateTask(req *corndogsv1alpha1.UpdateTaskRequest) (*corndogsv1alpha1.UpdateTaskResponse, error) {
 	taskProto := &corndogsv1alpha1.Task{}
-	if req.CurrentState == "" {
-		req.CurrentState = config.DefaultStartingState
-	}
-	if req.NewState == "" {
-		req.NewState = "updated"
-	}
-	if req.AutoTargetState == "" {
-		req.AutoTargetState = req.NewState + config.DefaultWorkingSuffix
-	}
 	err := DB.Transaction(func(tx *gorm.DB) error {
 		model := models.Task{
 			UUID:         req.Uuid,

--- a/server/store/postgresstore/postgresstore.go
+++ b/server/store/postgresstore/postgresstore.go
@@ -62,6 +62,10 @@ func (s PostgresStore) Initialize() (func(), error) {
 	return func() { sqlDb.Close() }, nil
 }
 
+func (s PostgresStore) CleanUpTimedOut(atTime time.Time) error {
+	return fmt.Errorf("CleanUpTimedOut is unimplimented!")
+}
+
 func (s PostgresStore) SubmitTask(req *corndogsv1alpha1.SubmitTaskRequest) (*corndogsv1alpha1.SubmitTaskResponse, error) {
 	taskProto := &corndogsv1alpha1.Task{}
 	newUuid, _ := uuid.NewRandom()

--- a/server/store/postgresstore/postgresstore.go
+++ b/server/store/postgresstore/postgresstore.go
@@ -75,12 +75,6 @@ func (s PostgresStore) SubmitTask(req *corndogsv1alpha1.SubmitTaskRequest) (*cor
 		req.AutoTargetState = req.CurrentState + DefaultWorkingSuffix
 	}
 
-	// Sudo code for later
-	// TODO: if == 0 set default
-	// if < 0 set to 0 in DB.
-	if req.Timeout < 0 {
-		req.Timeout = 0
-	}
 	err := DB.Transaction(func(tx *gorm.DB) error {
 		model := models.Task{
 			UUID:            newUuid.String(),

--- a/server/store/postgresstore/postgresstore.go
+++ b/server/store/postgresstore/postgresstore.go
@@ -198,17 +198,7 @@ func (s PostgresStore) GetNextTask(req *corndogsv1alpha1.GetNextTaskRequest) (*c
 		// swap states so if a timeout occurs we set them back to what they were
 		model.CurrentState = model.AutoTargetState
 		model.AutoTargetState = req.CurrentState
-		if req.Timeout != 0 {
-			// Since protobuf default int values are 0, if they wanted 0, they have to send a negative value
-			// which is otherwise invalid as a timeout
-			if req.Timeout < 0 {
-				model.Timeout = 0
-			} else {
-				model.Timeout = req.Timeout
-			}
-		} else {
-			// TODO: set default
-		}
+		model.Timeout = req.Timeout
 		result = DB.Save(model)
 		if result.Error != nil {
 			if errors.Is(result.Error, gorm.ErrRecordNotFound) || result.RowsAffected == 0 {

--- a/server/store/postgresstore/postgresstore.go
+++ b/server/store/postgresstore/postgresstore.go
@@ -349,7 +349,11 @@ func (s PostgresStore) CleanUpTimedOut(req *corndogsv1alpha1.CleanUpTimedOutRequ
 	var count int64 = 0
 	err := DB.Transaction(func(tx *gorm.DB) error {
 		model := models.Task{}
-		result := DB.Model(model).Where("timeout > 0 AND (update_time + (timeout * ?)) < ?", time.Second.Nanoseconds(), req.AtTime).Updates(
+		result := DB.Model(model).Where(`
+			timeout > 0 AND
+			(update_time + (timeout * ?)) < ? AND
+			((? = '') OR (? <> '' AND queue = ?))
+		`, time.Second.Nanoseconds(), req.AtTime, req.Queue, req.Queue, req.Queue).Updates(
 			map[string]interface{}{
 				"current_state":     gorm.Expr("auto_target_state"),
 				"auto_target_state": gorm.Expr("current_state"),

--- a/server/store/storeinterface.go
+++ b/server/store/storeinterface.go
@@ -1,11 +1,16 @@
 package store
 
-import corndogsv1alpha1 "github.com/TnLCommunity/protos-corndogs/gen/proto/go/corndogs/v1alpha1"
+import (
+	"time"
+
+	corndogsv1alpha1 "github.com/TnLCommunity/protos-corndogs/gen/proto/go/corndogs/v1alpha1"
+)
 
 var AppStore Store
 
 type Store interface {
 	Initialize() (deferredFunc func(), err error)
+	CleanUpTimedOut(atTime time.Time) error
 
 	SubmitTask(req *corndogsv1alpha1.SubmitTaskRequest) (*corndogsv1alpha1.SubmitTaskResponse, error)
 	MustGetTaskStateByID(req *corndogsv1alpha1.GetTaskStateByIDRequest) *corndogsv1alpha1.GetTaskStateByIDResponse

--- a/server/store/storeinterface.go
+++ b/server/store/storeinterface.go
@@ -1,8 +1,6 @@
 package store
 
 import (
-	"time"
-
 	corndogsv1alpha1 "github.com/TnLCommunity/protos-corndogs/gen/proto/go/corndogs/v1alpha1"
 )
 
@@ -10,7 +8,6 @@ var AppStore Store
 
 type Store interface {
 	Initialize() (deferredFunc func(), err error)
-	CleanUpTimedOut(atTime time.Time) error
 
 	SubmitTask(req *corndogsv1alpha1.SubmitTaskRequest) (*corndogsv1alpha1.SubmitTaskResponse, error)
 	MustGetTaskStateByID(req *corndogsv1alpha1.GetTaskStateByIDRequest) *corndogsv1alpha1.GetTaskStateByIDResponse
@@ -18,6 +15,7 @@ type Store interface {
 	UpdateTask(req *corndogsv1alpha1.UpdateTaskRequest) (*corndogsv1alpha1.UpdateTaskResponse, error)
 	CompleteTask(req *corndogsv1alpha1.CompleteTaskRequest) (*corndogsv1alpha1.CompleteTaskResponse, error)
 	CancelTask(req *corndogsv1alpha1.CancelTaskRequest) (*corndogsv1alpha1.CancelTaskResponse, error)
+	CleanUpTimedOut(req *corndogsv1alpha1.CleanUpTimedOutRequest) (*corndogsv1alpha1.CleanUpTimedOutResponse, error)
 }
 
 func SetStore(store Store) {

--- a/server/subprocesses/timeout.go
+++ b/server/subprocesses/timeout.go
@@ -1,0 +1,9 @@
+package subprocesses
+
+import (
+	"time"
+)
+
+func CleanUpTimedOut(atTime time.Time) error {
+	return nil
+}

--- a/server/subprocesses/timeout.go
+++ b/server/subprocesses/timeout.go
@@ -1,9 +1,0 @@
-package subprocesses
-
-import (
-	"time"
-)
-
-func CleanUpTimedOut(atTime time.Time) error {
-	return nil
-}

--- a/test/crud_test.go
+++ b/test/crud_test.go
@@ -3,7 +3,6 @@ package test
 import (
 	"context"
 	"fmt"
-	"math/rand"
 	"testing"
 	"time"
 
@@ -23,7 +22,7 @@ var testID = gofakeit.Breakfast() + gofakeit.Dessert()
 func init() {
 	// Get the next task in the test_via_core_corndogs_repo queue, which should be none
 	getNextRequest := &corndogsv1alpha1.GetNextTaskRequest{
-		Queue:        "testQueue" + testID,
+		Queue:        "testQueue" + GetTestID(),
 		CurrentState: "submitted",
 	}
 	nextTaskResponse, err := client.GetNextTask(context.Background(), getNextRequest)
@@ -36,8 +35,8 @@ func init() {
 }
 
 func TestBasicFlow(t *testing.T) {
+	testID := GetTestID()
 	corndogsClient := GetCorndogsClient()
-	rand.Seed(time.Now().UnixNano())
 	workingTaskSuffix := "-working"
 	testPayload := []byte("testPayload" + testID)
 
@@ -120,8 +119,8 @@ func TestBasicFlow(t *testing.T) {
 }
 
 func TestGetNextTaskOverrideState(t *testing.T) {
+	testID := GetTestID()
 	corndogsClient := GetCorndogsClient()
-	rand.Seed(time.Now().UnixNano())
 	workingTaskSuffix := "-working"
 	testPayload := []byte("testPayload" + testID)
 
@@ -167,4 +166,8 @@ func GetCorndogsClient() corndogsv1alpha1.CorndogsServiceClient {
 	}
 	cancel()
 	return corndogsv1alpha1.NewCorndogsServiceClient(conn)
+}
+
+func GetTestID() string {
+	return gofakeit.Breakfast() + gofakeit.Dessert()
 }

--- a/test/timeout_test.go
+++ b/test/timeout_test.go
@@ -254,3 +254,49 @@ func TestGetNextTaskOverrideNoTimeout(t *testing.T) {
 	require.Nil(t, err, fmt.Sprintf("error should be nil. error: \n%v", err))
 	require.Equal(t, int64(0), cleanUpTimedOutResponse.TimedOut)
 }
+
+func TestGetNextTaskOverrideTimeoutNotSet(t *testing.T) {
+	corndogsClient := GetCorndogsClient()
+	rand.Seed(time.Now().UnixNano())
+	workingTaskSuffix := "-working"
+	testPayload := []byte("testPayload" + testID)
+	var timeout int64 = 5
+
+	submitTaskRequest := &corndogsv1alpha1.SubmitTaskRequest{
+		Queue:           "testQueue" + testID,
+		CurrentState:    "testSubmitted",
+		AutoTargetState: "testSubmitted" + workingTaskSuffix,
+		Timeout:         timeout,
+		Payload:         testPayload,
+	}
+	submitTaskResponse, err := corndogsClient.SubmitTask(context.Background(), submitTaskRequest)
+	require.Nil(t, err, fmt.Sprintf("error should be nil. error: \n%v", err))
+	require.NotNil(t, submitTaskResponse.Task, "Task in response was nil")
+	require.Equal(t, submitTaskRequest.Queue, submitTaskResponse.Task.Queue, "Queue name is not equal")
+	require.NotEmpty(t, submitTaskResponse.Task.SubmitTime, "submit_time should not be empty")
+	require.NotEmpty(t, submitTaskResponse.Task.UpdateTime, "update_time should not be empty")
+	require.NotEmpty(t, submitTaskResponse.Task.Uuid, "uuid should not be empty")
+
+	getNextTaskRequest := &corndogsv1alpha1.GetNextTaskRequest{
+		Queue:        "testQueue" + testID,
+		CurrentState: "testSubmitted",
+	}
+	getNextTaskResponse, err := corndogsClient.GetNextTask(context.Background(), getNextTaskRequest)
+	require.Nil(t, err, fmt.Sprintf("error should be nil. error: \n%v", err))
+	require.NotNil(t, getNextTaskResponse.Task, "Task in response was nil")
+	require.Equal(t, getNextTaskRequest.Queue, getNextTaskResponse.Task.Queue, "Queue name is not equal")
+	require.NotEmpty(t, getNextTaskResponse.Task.SubmitTime, "submit_time should not be empty")
+	require.NotEmpty(t, getNextTaskResponse.Task.UpdateTime, "update_time should not be empty")
+	require.NotEmpty(t, getNextTaskResponse.Task.Uuid, "uuid should not be empty")
+	require.NotEqual(t, int64(0), getNextTaskResponse.Task.Timeout, "Task Timeout was wrongly overriden")
+	require.Equal(t, timeout, getNextTaskResponse.Task.Timeout, "Task Timeout is not equal")
+
+	timeoutDuration := time.Duration(timeout) * time.Second
+	timeWhenTimedout := time.Now().UTC().Add(timeoutDuration).UnixNano()
+	cleanUpTimedOutRequest := &corndogsv1alpha1.CleanUpTimedOutRequest{
+		AtTime: timeWhenTimedout,
+	}
+	cleanUpTimedOutResponse, err := corndogsClient.CleanUpTimedOut(context.Background(), cleanUpTimedOutRequest)
+	require.Nil(t, err, fmt.Sprintf("error should be nil. error: \n%v", err))
+	require.Equal(t, int64(1), cleanUpTimedOutResponse.TimedOut)
+}

--- a/test/timeout_test.go
+++ b/test/timeout_test.go
@@ -58,13 +58,13 @@ func TestBasicTimeout(t *testing.T) {
 	require.Equal(t, getNextTaskRequest.CurrentState+workingTaskSuffix, getNextTaskResponse.Task.CurrentState, "Task CurrentState is not the auto target state from before retrieval")
 	require.Equal(t, getNextTaskRequest.CurrentState, getNextTaskResponse.Task.AutoTargetState, "Task AutoTargetState is not swapped with current state before retrieval")
 
-	timeWhenTimedout := time.Now().Add(timeoutDuration)
+	timeWhenTimedout := time.Now().UTC().Add(timeoutDuration).UnixNano()
 	cleanUpTimedOutRequest := &corndogsv1alpha1.CleanUpTimedOutRequest{
-		AtTime: timeWhenTimedout.UnixNano(),
+		AtTime: timeWhenTimedout,
 	}
 	cleanUpTimedOutResponse, err := corndogsClient.CleanUpTimedOut(context.Background(), cleanUpTimedOutRequest)
 	require.Nil(t, err, fmt.Sprintf("error should be nil. error: \n%v", err))
-	require.Equal(t, cleanUpTimedOutResponse.TimedOut, 1)
+	require.Equal(t, int64(1), cleanUpTimedOutResponse.TimedOut)
 
 	// If everything is working this should be the same, meaning things like the state are returned to their previous values.
 	getNextTaskResponse, err = corndogsClient.GetNextTask(context.Background(), getNextTaskRequest)

--- a/test/timeout_test.go
+++ b/test/timeout_test.go
@@ -73,46 +73,6 @@ func TestBasicTimeout(t *testing.T) {
 	require.Equal(t, getNextTaskRequest.CurrentState, getNextTaskResponse.Task.AutoTargetState, "Task AutoTargetState is not swapped with current state before retrieval")
 }
 
-// func TestTimeoutDefault(t *testing.T) {
-// 	corndogsClient := GetCorndogsClient()
-// 	rand.Seed(time.Now().UnixNano())
-// 	workingTaskSuffix := "-working"
-// 	testPayload := []byte("testPayload" + testID)
-//  testQueue := "testQueue" + testID
-// 	var timeout int64 = 0
-
-// 	submitTaskRequest := &corndogsv1alpha1.SubmitTaskRequest{
-// 		Queue: testQueue,
-// 		CurrentState:    "testSubmitted",
-// 		AutoTargetState: "testSubmitted" + workingTaskSuffix,
-// 		Timeout:         timeout,
-// 		Payload:         testPayload,
-// 	}
-// 	submitTaskResponse, err := corndogsClient.SubmitTask(context.Background(), submitTaskRequest)
-// 	require.Nil(t, err, fmt.Sprintf("error should be nil. error: \n%v", err))
-// 	require.NotNil(t, submitTaskResponse.Task, "Task in response was nil")
-// 	require.Equal(t, submitTaskRequest.Queue, submitTaskResponse.Task.Queue, "Queue name is not equal")
-// 	require.NotEqual(t, 0, submitTaskResponse.Task.Timeout, "Timeout shouldnt still be zero")
-// 	require.NotEmpty(t, submitTaskResponse.Task.SubmitTime, "submit_time should not be empty")
-// 	require.NotEmpty(t, submitTaskResponse.Task.UpdateTime, "update_time should not be empty")
-// 	require.NotEmpty(t, submitTaskResponse.Task.Uuid, "uuid should not be empty")
-
-// 	getNextTaskRequest := &corndogsv1alpha1.GetNextTaskRequest{
-// 		Queue: testQueue,
-// 		CurrentState: "testSubmitted",
-// 	}
-// 	getNextTaskResponse, err := corndogsClient.GetNextTask(context.Background(), getNextTaskRequest)
-// 	require.Nil(t, err, fmt.Sprintf("error should be nil. error: \n%v", err))
-// 	require.NotNil(t, getNextTaskResponse.Task, "Task in response was nil")
-// 	require.Equal(t, getNextTaskRequest.Queue, getNextTaskResponse.Task.Queue, "Queue name is not equal")
-// 	require.Equal(t, timeout, getNextTaskResponse.Task.Timeout, "Timeout is not equal")
-// 	require.NotEmpty(t, getNextTaskResponse.Task.SubmitTime, "submit_time should not be empty")
-// 	require.NotEmpty(t, getNextTaskResponse.Task.UpdateTime, "update_time should not be empty")
-// 	require.NotEmpty(t, getNextTaskResponse.Task.Uuid, "uuid should not be empty")
-// 	require.Equal(t, getNextTaskRequest.CurrentState+workingTaskSuffix, getNextTaskResponse.Task.CurrentState, "Task CurrentState is not the auto target state from before retrieval")
-// 	require.Equal(t, getNextTaskRequest.CurrentState, getNextTaskResponse.Task.AutoTargetState, "Task AutoTargetState is not swapped with current state before retrieval")
-// }
-
 func TestNoTimeout(t *testing.T) {
 	corndogsClient := GetCorndogsClient()
 	rand.Seed(time.Now().UnixNano())

--- a/test/timeout_test.go
+++ b/test/timeout_test.go
@@ -3,7 +3,6 @@ package test
 import (
 	"context"
 	"fmt"
-	"math/rand"
 	"testing"
 	"time"
 
@@ -12,8 +11,8 @@ import (
 )
 
 func TestBasicTimeout(t *testing.T) {
+	testID := GetTestID()
 	corndogsClient := GetCorndogsClient()
-	rand.Seed(time.Now().UnixNano())
 	workingTaskSuffix := "-working"
 	testPayload := []byte("testPayload" + testID)
 	testQueue := "testQueue" + testID
@@ -74,8 +73,8 @@ func TestBasicTimeout(t *testing.T) {
 }
 
 func TestNoTimeout(t *testing.T) {
+	testID := GetTestID()
 	corndogsClient := GetCorndogsClient()
-	rand.Seed(time.Now().UnixNano())
 	workingTaskSuffix := "-working"
 	testPayload := []byte("testPayload" + testID)
 	testQueue := "testQueue" + testID
@@ -129,8 +128,8 @@ func TestNoTimeout(t *testing.T) {
 }
 
 func TestGetNextTaskOverrideTimeout(t *testing.T) {
+	testID := GetTestID()
 	corndogsClient := GetCorndogsClient()
-	rand.Seed(time.Now().UnixNano())
 	workingTaskSuffix := "-working"
 	testPayload := []byte("testPayload" + testID)
 	testQueue := "testQueue" + testID
@@ -177,8 +176,8 @@ func TestGetNextTaskOverrideTimeout(t *testing.T) {
 }
 
 func TestGetNextTaskOverrideNoTimeout(t *testing.T) {
+	testID := GetTestID()
 	corndogsClient := GetCorndogsClient()
-	rand.Seed(time.Now().UnixNano())
 	workingTaskSuffix := "-working"
 	testPayload := []byte("testPayload" + testID)
 	testQueue := "testQueue" + testID
@@ -225,8 +224,8 @@ func TestGetNextTaskOverrideNoTimeout(t *testing.T) {
 }
 
 func TestGetNextTaskOverrideTimeoutNotSet(t *testing.T) {
+	testID := GetTestID()
 	corndogsClient := GetCorndogsClient()
-	rand.Seed(time.Now().UnixNano())
 	workingTaskSuffix := "-working"
 	testPayload := []byte("testPayload" + testID)
 	testQueue := "testQueue" + testID
@@ -273,8 +272,8 @@ func TestGetNextTaskOverrideTimeoutNotSet(t *testing.T) {
 }
 
 func TestTimeoutSpecificQueue(t *testing.T) {
+	testID := GetTestID()
 	corndogsClient := GetCorndogsClient()
-	rand.Seed(time.Now().UnixNano())
 	workingTaskSuffix := "-working"
 	testPayload := []byte("testPayload" + testID)
 	testQueue := "testQueue" + testID
@@ -331,8 +330,8 @@ func TestTimeoutSpecificQueue(t *testing.T) {
 }
 
 func TestTimeoutNoQueue(t *testing.T) {
+	testID := GetTestID()
 	corndogsClient := GetCorndogsClient()
-	rand.Seed(time.Now().UnixNano())
 	workingTaskSuffix := "-working"
 	testPayload := []byte("testPayload" + testID)
 	testQueue := "testQueue" + testID

--- a/test/timeout_test.go
+++ b/test/timeout_test.go
@@ -267,3 +267,61 @@ func TestGetNextTaskOverrideTimeoutNotSet(t *testing.T) {
 	require.Nil(t, err, fmt.Sprintf("error should be nil. error: \n%v", err))
 	require.Equal(t, int64(1), cleanUpTimedOutResponse.TimedOut)
 }
+
+func TestTimeoutSpecificQueue(t *testing.T) {
+	corndogsClient := GetCorndogsClient()
+	rand.Seed(time.Now().UnixNano())
+	workingTaskSuffix := "-working"
+	testPayload := []byte("testPayload" + testID)
+	testQueue := "testQueue" + testID
+	var timeout int64 = 5
+	queueSuffix := []string{"first", "second"}
+
+	// Create and get a task in each queue
+	for _, suffix := range queueSuffix {
+		submitTaskRequest := &corndogsv1alpha1.SubmitTaskRequest{
+			Queue:           testQueue + suffix,
+			CurrentState:    "testSubmitted",
+			AutoTargetState: "testSubmitted" + workingTaskSuffix,
+			Timeout:         timeout,
+			Payload:         testPayload,
+		}
+
+		submitTaskResponse, err := corndogsClient.SubmitTask(context.Background(), submitTaskRequest)
+		require.Nil(t, err, fmt.Sprintf("error should be nil. error: \n%v", err))
+		require.NotNil(t, submitTaskResponse.Task, "Task in response was nil")
+		require.Equal(t, submitTaskRequest.Queue, submitTaskResponse.Task.Queue, "Queue name is not equal")
+		require.Equal(t, timeout, submitTaskResponse.Task.Timeout, "Timeout should be 0")
+		require.NotEmpty(t, submitTaskResponse.Task.SubmitTime, "submit_time should not be empty")
+		require.NotEmpty(t, submitTaskResponse.Task.UpdateTime, "update_time should not be empty")
+		require.NotEmpty(t, submitTaskResponse.Task.Uuid, "uuid should not be empty")
+
+		getNextTaskRequest := &corndogsv1alpha1.GetNextTaskRequest{
+			Queue:        testQueue + suffix,
+			CurrentState: "testSubmitted",
+		}
+		getNextTaskResponse, err := corndogsClient.GetNextTask(context.Background(), getNextTaskRequest)
+		require.Nil(t, err, fmt.Sprintf("error should be nil. error: \n%v", err))
+		require.NotNil(t, getNextTaskResponse.Task, "Task in response was nil")
+		require.Equal(t, getNextTaskRequest.Queue, getNextTaskResponse.Task.Queue, "Queue name is not equal")
+		require.Equal(t, timeout, getNextTaskResponse.Task.Timeout, "Timeout should be zero meaning no timeout")
+		require.NotEmpty(t, getNextTaskResponse.Task.SubmitTime, "submit_time should not be empty")
+		require.NotEmpty(t, getNextTaskResponse.Task.UpdateTime, "update_time should not be empty")
+		require.NotEmpty(t, getNextTaskResponse.Task.Uuid, "uuid should not be empty")
+		require.Equal(t, getNextTaskRequest.CurrentState+workingTaskSuffix, getNextTaskResponse.Task.CurrentState, "Task CurrentState is not the auto target state from before retrieval")
+		require.Equal(t, getNextTaskRequest.CurrentState, getNextTaskResponse.Task.AutoTargetState, "Task AutoTargetState is not swapped with current state before retrieval")
+	}
+
+	// Timeout each queue individually
+	for _, suffix := range queueSuffix {
+		timeoutDuration := time.Duration(timeout) * time.Second
+		timeWhenTimedout := time.Now().UTC().Add(timeoutDuration).UnixNano()
+		cleanUpTimedOutRequest := &corndogsv1alpha1.CleanUpTimedOutRequest{
+			AtTime: timeWhenTimedout,
+			Queue:  testQueue + suffix,
+		}
+		cleanUpTimedOutResponse, err := corndogsClient.CleanUpTimedOut(context.Background(), cleanUpTimedOutRequest)
+		require.Nil(t, err, fmt.Sprintf("error should be nil. error: \n%v", err))
+		require.Equal(t, int64(1), cleanUpTimedOutResponse.TimedOut, "didnt time out specific queue")
+	}
+}

--- a/test/timeout_test.go
+++ b/test/timeout_test.go
@@ -382,5 +382,5 @@ func TestTimeoutNoQueue(t *testing.T) {
 	}
 	cleanUpTimedOutResponse, err := corndogsClient.CleanUpTimedOut(context.Background(), cleanUpTimedOutRequest)
 	require.Nil(t, err, fmt.Sprintf("error should be nil. error: \n%v", err))
-	require.GreaterOrEqual(t, int64(2), cleanUpTimedOutResponse.TimedOut, "didnt time out multiple queues")
+	require.GreaterOrEqual(t, cleanUpTimedOutResponse.TimedOut, int64(2), "didnt time out multiple queues")
 }

--- a/test/timeout_test.go
+++ b/test/timeout_test.go
@@ -16,11 +16,12 @@ func TestBasicTimeout(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
 	workingTaskSuffix := "-working"
 	testPayload := []byte("testPayload" + testID)
+	testQueue := "testQueue" + testID
 	var timeout int64 = 5
 	timeoutDuration := time.Duration(timeout) * time.Second
 
 	submitTaskRequest := &corndogsv1alpha1.SubmitTaskRequest{
-		Queue:           "testQueue" + testID,
+		Queue:           testQueue,
 		CurrentState:    "testSubmitted",
 		AutoTargetState: "testSubmitted" + workingTaskSuffix,
 		Timeout:         timeout,
@@ -36,7 +37,7 @@ func TestBasicTimeout(t *testing.T) {
 	require.NotEmpty(t, submitTaskResponse.Task.Uuid, "uuid should not be empty")
 
 	getNextTaskRequest := &corndogsv1alpha1.GetNextTaskRequest{
-		Queue:        "testQueue" + testID,
+		Queue:        testQueue,
 		CurrentState: "testSubmitted",
 	}
 	getNextTaskResponse, err := corndogsClient.GetNextTask(context.Background(), getNextTaskRequest)
@@ -53,6 +54,7 @@ func TestBasicTimeout(t *testing.T) {
 	timeWhenTimedout := time.Now().UTC().Add(timeoutDuration).UnixNano()
 	cleanUpTimedOutRequest := &corndogsv1alpha1.CleanUpTimedOutRequest{
 		AtTime: timeWhenTimedout,
+		Queue:  testQueue,
 	}
 	cleanUpTimedOutResponse, err := corndogsClient.CleanUpTimedOut(context.Background(), cleanUpTimedOutRequest)
 	require.Nil(t, err, fmt.Sprintf("error should be nil. error: \n%v", err))
@@ -76,10 +78,11 @@ func TestBasicTimeout(t *testing.T) {
 // 	rand.Seed(time.Now().UnixNano())
 // 	workingTaskSuffix := "-working"
 // 	testPayload := []byte("testPayload" + testID)
+//  testQueue := "testQueue" + testID
 // 	var timeout int64 = 0
 
 // 	submitTaskRequest := &corndogsv1alpha1.SubmitTaskRequest{
-// 		Queue:           "testQueue" + testID,
+// 		Queue: testQueue,
 // 		CurrentState:    "testSubmitted",
 // 		AutoTargetState: "testSubmitted" + workingTaskSuffix,
 // 		Timeout:         timeout,
@@ -95,7 +98,7 @@ func TestBasicTimeout(t *testing.T) {
 // 	require.NotEmpty(t, submitTaskResponse.Task.Uuid, "uuid should not be empty")
 
 // 	getNextTaskRequest := &corndogsv1alpha1.GetNextTaskRequest{
-// 		Queue:        "testQueue" + testID,
+// 		Queue: testQueue,
 // 		CurrentState: "testSubmitted",
 // 	}
 // 	getNextTaskResponse, err := corndogsClient.GetNextTask(context.Background(), getNextTaskRequest)
@@ -115,10 +118,11 @@ func TestNoTimeout(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
 	workingTaskSuffix := "-working"
 	testPayload := []byte("testPayload" + testID)
+	testQueue := "testQueue" + testID
 	var timeout int64 = -1
 
 	submitTaskRequest := &corndogsv1alpha1.SubmitTaskRequest{
-		Queue:           "testQueue" + testID,
+		Queue:           testQueue,
 		CurrentState:    "testSubmitted",
 		AutoTargetState: "testSubmitted" + workingTaskSuffix,
 		Timeout:         timeout,
@@ -135,7 +139,7 @@ func TestNoTimeout(t *testing.T) {
 	require.NotEmpty(t, submitTaskResponse.Task.Uuid, "uuid should not be empty")
 
 	getNextTaskRequest := &corndogsv1alpha1.GetNextTaskRequest{
-		Queue:        "testQueue" + testID,
+		Queue:        testQueue,
 		CurrentState: "testSubmitted",
 	}
 	getNextTaskResponse, err := corndogsClient.GetNextTask(context.Background(), getNextTaskRequest)
@@ -168,10 +172,11 @@ func TestGetNextTaskOverrideTimeout(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
 	workingTaskSuffix := "-working"
 	testPayload := []byte("testPayload" + testID)
+	testQueue := "testQueue" + testID
 	var timeout int64 = 5
 
 	submitTaskRequest := &corndogsv1alpha1.SubmitTaskRequest{
-		Queue:           "testQueue" + testID,
+		Queue:           testQueue,
 		CurrentState:    "testSubmitted",
 		AutoTargetState: "testSubmitted" + workingTaskSuffix,
 		Timeout:         -1, // No timeout
@@ -186,7 +191,7 @@ func TestGetNextTaskOverrideTimeout(t *testing.T) {
 	require.NotEmpty(t, submitTaskResponse.Task.Uuid, "uuid should not be empty")
 
 	getNextTaskRequest := &corndogsv1alpha1.GetNextTaskRequest{
-		Queue:           "testQueue" + testID,
+		Queue:           testQueue,
 		CurrentState:    "testSubmitted",
 		OverrideTimeout: timeout,
 	}
@@ -214,10 +219,11 @@ func TestGetNextTaskOverrideNoTimeout(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
 	workingTaskSuffix := "-working"
 	testPayload := []byte("testPayload" + testID)
+	testQueue := "testQueue" + testID
 	var timeout int64 = 5
 
 	submitTaskRequest := &corndogsv1alpha1.SubmitTaskRequest{
-		Queue:           "testQueue" + testID,
+		Queue:           testQueue,
 		CurrentState:    "testSubmitted",
 		AutoTargetState: "testSubmitted" + workingTaskSuffix,
 		Timeout:         timeout,
@@ -232,7 +238,7 @@ func TestGetNextTaskOverrideNoTimeout(t *testing.T) {
 	require.NotEmpty(t, submitTaskResponse.Task.Uuid, "uuid should not be empty")
 
 	getNextTaskRequest := &corndogsv1alpha1.GetNextTaskRequest{
-		Queue:           "testQueue" + testID,
+		Queue:           testQueue,
 		CurrentState:    "testSubmitted",
 		OverrideTimeout: -1, // No timeout
 	}
@@ -260,10 +266,11 @@ func TestGetNextTaskOverrideTimeoutNotSet(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
 	workingTaskSuffix := "-working"
 	testPayload := []byte("testPayload" + testID)
+	testQueue := "testQueue" + testID
 	var timeout int64 = 5
 
 	submitTaskRequest := &corndogsv1alpha1.SubmitTaskRequest{
-		Queue:           "testQueue" + testID,
+		Queue:           testQueue,
 		CurrentState:    "testSubmitted",
 		AutoTargetState: "testSubmitted" + workingTaskSuffix,
 		Timeout:         timeout,
@@ -278,7 +285,7 @@ func TestGetNextTaskOverrideTimeoutNotSet(t *testing.T) {
 	require.NotEmpty(t, submitTaskResponse.Task.Uuid, "uuid should not be empty")
 
 	getNextTaskRequest := &corndogsv1alpha1.GetNextTaskRequest{
-		Queue:        "testQueue" + testID,
+		Queue:        testQueue,
 		CurrentState: "testSubmitted",
 	}
 	getNextTaskResponse, err := corndogsClient.GetNextTask(context.Background(), getNextTaskRequest)

--- a/test/timeout_test.go
+++ b/test/timeout_test.go
@@ -1,0 +1,92 @@
+package test
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/TnLCommunity/corndogs/server/subprocesses"
+	corndogsv1alpha1 "github.com/TnLCommunity/protos-corndogs/gen/proto/go/corndogs/v1alpha1"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBasicTimeout(t *testing.T) {
+	corndogsClient := GetCorndogsClient()
+	rand.Seed(time.Now().UnixNano())
+	workingTaskSuffix := "-working"
+	testPayload := []byte("testPayload" + testID)
+	var timeout int64 = 5
+	timeoutDuration := time.Duration(timeout) * time.Second
+
+	submitTaskRequest := &corndogsv1alpha1.SubmitTaskRequest{
+		Queue:           "testQueue" + testID,
+		CurrentState:    "testSubmitted",
+		AutoTargetState: "testSubmitted" + workingTaskSuffix,
+		Timeout:         timeout,
+		Payload:         testPayload,
+	}
+	/*
+		TEST 1
+		send with timeout.
+		cleanup timed out
+		check timed out.
+		check CurrentState returns back to previous
+	*/
+
+	submitTaskResponse, err := corndogsClient.SubmitTask(context.Background(), submitTaskRequest)
+	require.Nil(t, err, fmt.Sprintf("error should be nil. error: \n%v", err))
+	require.NotNil(t, submitTaskResponse.Task, "Task in response was nil")
+	require.Equal(t, submitTaskRequest.Queue, submitTaskResponse.Task.Queue, "Queue name is not equal")
+	require.Equal(t, timeout, submitTaskResponse.Task.Timeout, "Timeout is not equal")
+	require.NotEmpty(t, submitTaskResponse.Task.SubmitTime, "submit_time should not be empty")
+	require.NotEmpty(t, submitTaskResponse.Task.UpdateTime, "update_time should not be empty")
+	require.NotEmpty(t, submitTaskResponse.Task.Uuid, "uuid should not be empty")
+
+	getNextTaskRequest := &corndogsv1alpha1.GetNextTaskRequest{
+		Queue:        "testQueue" + testID,
+		CurrentState: "testSubmitted",
+	}
+	getNextTaskResponse, err := corndogsClient.GetNextTask(context.Background(), getNextTaskRequest)
+	require.Nil(t, err, fmt.Sprintf("error should be nil. error: \n%v", err))
+	require.NotNil(t, getNextTaskResponse.Task, "Task in response was nil")
+	require.Equal(t, getNextTaskRequest.Queue, getNextTaskResponse.Task.Queue, "Queue name is not equal")
+	require.Equal(t, timeout, getNextTaskResponse.Task.Timeout, "Timeout is not equal")
+	require.NotEmpty(t, getNextTaskResponse.Task.SubmitTime, "submit_time should not be empty")
+	require.NotEmpty(t, getNextTaskResponse.Task.UpdateTime, "update_time should not be empty")
+	require.NotEmpty(t, getNextTaskResponse.Task.Uuid, "uuid should not be empty")
+	require.Equal(t, getNextTaskRequest.CurrentState+workingTaskSuffix, getNextTaskResponse.Task.CurrentState, "Task CurrentState is not the auto target state from before retrieval")
+	require.Equal(t, getNextTaskRequest.CurrentState, getNextTaskResponse.Task.AutoTargetState, "Task AutoTargetState is not swapped with current state before retrieval")
+
+	timeWhenTimedout := time.Now().Add(timeoutDuration)
+	err = subprocesses.CleanUpTimedOut(timeWhenTimedout)
+	require.Nil(t, err, fmt.Sprintf("error should be nil. error: \n%v", err))
+
+	// If everything is working this should be the same, meaning things like the state are returned to their previous values.
+	getNextTaskResponse, err = corndogsClient.GetNextTask(context.Background(), getNextTaskRequest)
+	require.Nil(t, err, fmt.Sprintf("error should be nil. error: \n%v", err))
+	require.NotNil(t, getNextTaskResponse.Task, "Task in response was nil")
+	require.Equal(t, getNextTaskRequest.Queue, getNextTaskResponse.Task.Queue, "Queue name is not equal")
+	require.Equal(t, timeout, getNextTaskResponse.Task.Timeout, "Timeout is not equal")
+	require.NotEmpty(t, getNextTaskResponse.Task.SubmitTime, "submit_time should not be empty")
+	require.NotEmpty(t, getNextTaskResponse.Task.UpdateTime, "update_time should not be empty")
+	require.NotEmpty(t, getNextTaskResponse.Task.Uuid, "uuid should not be empty")
+	require.Equal(t, getNextTaskRequest.CurrentState+workingTaskSuffix, getNextTaskResponse.Task.CurrentState, "Task CurrentState is not the auto target state from before retrieval")
+	require.Equal(t, getNextTaskRequest.CurrentState, getNextTaskResponse.Task.AutoTargetState, "Task AutoTargetState is not swapped with current state before retrieval")
+}
+
+func TestTimeoutDefault(t *testing.T) {
+	// TEST 2
+	// send with timeout 0
+	// check timeout is default
+}
+
+func TestNoTimeout(t *testing.T) {
+	// TEST 3
+	// send with timeout -1
+	// check timeout is 0 in DB?
+	// cleanup timed out
+	// Check it did not timeout
+	// Check CurrentState is the same as the working state
+}

--- a/test/timeout_test.go
+++ b/test/timeout_test.go
@@ -208,3 +208,49 @@ func TestGetNextTaskOverrideTimeout(t *testing.T) {
 	require.Nil(t, err, fmt.Sprintf("error should be nil. error: \n%v", err))
 	require.Equal(t, int64(1), cleanUpTimedOutResponse.TimedOut)
 }
+
+func TestGetNextTaskOverrideNoTimeout(t *testing.T) {
+	corndogsClient := GetCorndogsClient()
+	rand.Seed(time.Now().UnixNano())
+	workingTaskSuffix := "-working"
+	testPayload := []byte("testPayload" + testID)
+	var timeout int64 = 5
+
+	submitTaskRequest := &corndogsv1alpha1.SubmitTaskRequest{
+		Queue:           "testQueue" + testID,
+		CurrentState:    "testSubmitted",
+		AutoTargetState: "testSubmitted" + workingTaskSuffix,
+		Timeout:         timeout,
+		Payload:         testPayload,
+	}
+	submitTaskResponse, err := corndogsClient.SubmitTask(context.Background(), submitTaskRequest)
+	require.Nil(t, err, fmt.Sprintf("error should be nil. error: \n%v", err))
+	require.NotNil(t, submitTaskResponse.Task, "Task in response was nil")
+	require.Equal(t, submitTaskRequest.Queue, submitTaskResponse.Task.Queue, "Queue name is not equal")
+	require.NotEmpty(t, submitTaskResponse.Task.SubmitTime, "submit_time should not be empty")
+	require.NotEmpty(t, submitTaskResponse.Task.UpdateTime, "update_time should not be empty")
+	require.NotEmpty(t, submitTaskResponse.Task.Uuid, "uuid should not be empty")
+
+	getNextTaskRequest := &corndogsv1alpha1.GetNextTaskRequest{
+		Queue:           "testQueue" + testID,
+		CurrentState:    "testSubmitted",
+		OverrideTimeout: -1, // No timeout
+	}
+	getNextTaskResponse, err := corndogsClient.GetNextTask(context.Background(), getNextTaskRequest)
+	require.Nil(t, err, fmt.Sprintf("error should be nil. error: \n%v", err))
+	require.NotNil(t, getNextTaskResponse.Task, "Task in response was nil")
+	require.Equal(t, getNextTaskRequest.Queue, getNextTaskResponse.Task.Queue, "Queue name is not equal")
+	require.NotEmpty(t, getNextTaskResponse.Task.SubmitTime, "submit_time should not be empty")
+	require.NotEmpty(t, getNextTaskResponse.Task.UpdateTime, "update_time should not be empty")
+	require.NotEmpty(t, getNextTaskResponse.Task.Uuid, "uuid should not be empty")
+	require.Equal(t, int64(0), getNextTaskResponse.Task.Timeout, "Task Timeout is not the overridden with 0")
+
+	timeoutDuration := time.Duration(timeout) * time.Second
+	timeWhenTimedout := time.Now().UTC().Add(timeoutDuration).UnixNano()
+	cleanUpTimedOutRequest := &corndogsv1alpha1.CleanUpTimedOutRequest{
+		AtTime: timeWhenTimedout,
+	}
+	cleanUpTimedOutResponse, err := corndogsClient.CleanUpTimedOut(context.Background(), cleanUpTimedOutRequest)
+	require.Nil(t, err, fmt.Sprintf("error should be nil. error: \n%v", err))
+	require.Equal(t, int64(0), cleanUpTimedOutResponse.TimedOut)
+}

--- a/test/timeout_test.go
+++ b/test/timeout_test.go
@@ -117,6 +117,7 @@ func TestNoTimeout(t *testing.T) {
 	timeWhenTimedout := time.Now().UTC().Add(timeoutDuration).UnixNano()
 	cleanUpTimedOutRequest := &corndogsv1alpha1.CleanUpTimedOutRequest{
 		AtTime: timeWhenTimedout,
+		Queue:  testQueue,
 	}
 	cleanUpTimedOutResponse, err := corndogsClient.CleanUpTimedOut(context.Background(), cleanUpTimedOutRequest)
 	require.Nil(t, err, fmt.Sprintf("error should be nil. error: \n%v", err))
@@ -168,6 +169,7 @@ func TestGetNextTaskOverrideTimeout(t *testing.T) {
 	timeWhenTimedout := time.Now().UTC().Add(timeoutDuration).UnixNano()
 	cleanUpTimedOutRequest := &corndogsv1alpha1.CleanUpTimedOutRequest{
 		AtTime: timeWhenTimedout,
+		Queue:  testQueue,
 	}
 	cleanUpTimedOutResponse, err := corndogsClient.CleanUpTimedOut(context.Background(), cleanUpTimedOutRequest)
 	require.Nil(t, err, fmt.Sprintf("error should be nil. error: \n%v", err))
@@ -215,6 +217,7 @@ func TestGetNextTaskOverrideNoTimeout(t *testing.T) {
 	timeWhenTimedout := time.Now().UTC().Add(timeoutDuration).UnixNano()
 	cleanUpTimedOutRequest := &corndogsv1alpha1.CleanUpTimedOutRequest{
 		AtTime: timeWhenTimedout,
+		Queue:  testQueue,
 	}
 	cleanUpTimedOutResponse, err := corndogsClient.CleanUpTimedOut(context.Background(), cleanUpTimedOutRequest)
 	require.Nil(t, err, fmt.Sprintf("error should be nil. error: \n%v", err))
@@ -262,6 +265,7 @@ func TestGetNextTaskOverrideTimeoutNotSet(t *testing.T) {
 	timeWhenTimedout := time.Now().UTC().Add(timeoutDuration).UnixNano()
 	cleanUpTimedOutRequest := &corndogsv1alpha1.CleanUpTimedOutRequest{
 		AtTime: timeWhenTimedout,
+		Queue:  testQueue,
 	}
 	cleanUpTimedOutResponse, err := corndogsClient.CleanUpTimedOut(context.Background(), cleanUpTimedOutRequest)
 	require.Nil(t, err, fmt.Sprintf("error should be nil. error: \n%v", err))

--- a/test/timeout_test.go
+++ b/test/timeout_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/TnLCommunity/corndogs/server/subprocesses"
 	corndogsv1alpha1 "github.com/TnLCommunity/protos-corndogs/gen/proto/go/corndogs/v1alpha1"
 	"github.com/stretchr/testify/require"
 )
@@ -60,8 +59,12 @@ func TestBasicTimeout(t *testing.T) {
 	require.Equal(t, getNextTaskRequest.CurrentState, getNextTaskResponse.Task.AutoTargetState, "Task AutoTargetState is not swapped with current state before retrieval")
 
 	timeWhenTimedout := time.Now().Add(timeoutDuration)
-	err = subprocesses.CleanUpTimedOut(timeWhenTimedout)
+	cleanUpTimedOutRequest := &corndogsv1alpha1.CleanUpTimedOutRequest{
+		AtTime: timeWhenTimedout.UnixNano(),
+	}
+	cleanUpTimedOutResponse, err := corndogsClient.CleanUpTimedOut(context.Background(), cleanUpTimedOutRequest)
 	require.Nil(t, err, fmt.Sprintf("error should be nil. error: \n%v", err))
+	require.Equal(t, cleanUpTimedOutResponse.TimedOut, 1)
 
 	// If everything is working this should be the same, meaning things like the state are returned to their previous values.
 	getNextTaskResponse, err = corndogsClient.GetNextTask(context.Background(), getNextTaskRequest)

--- a/values-skaffold-local.yaml
+++ b/values-skaffold-local.yaml
@@ -3,6 +3,10 @@ appconfig:
   loglevel: "error"
   prometheusEnabled: false
 
+timeoutCron:
+  enabled: false
+  schedule: "*/5 * * * *"
+
 database:
   dbname: "localcorndogsdev"
   host: "corndogs-postgresql"
@@ -16,7 +20,8 @@ database:
 
 postgresql:
   enabled: true
-  postgresqlDatabase: "localcorndogsdev"
-  postgresqlPassword: "localcorndogsdevpass"
+  auth:
+    database: "localcorndogsdev"
+    postgresPassword: "localcorndogsdevpass"
   tls:
     enabled: false


### PR DESCRIPTION
Currently draft because I just wrote everything below and I don't want to rewrite it.

Adds timeout functionality
- Corndogs server and store interfaces now have a `CleanUpTimedOut` method that accepts `CleanUpTimedOutRequest` with `at_time` to compare tasks against. The request also has an optional  `queue` field to limit the clean up to. Returns a `CleanUpTimedOutResponse` with a `timed_out` count.
- Postgres now implements the `CleanUpTimedOut` method. It sets timeouts to `0` so tasks are not timed out twice.
- GetNextTask can now override current_state, auto_target_state, and timeout. This allows for more complex workflows. An example is provided in [this protos-corndogs PR.](https://github.com/TnLCommunity/protos-corndogs/pull/11)
- Corndogs now uses a cli tool to run the server. This allows for future extensions and helpers such as the new `timeout` command
- Added a `timeout` command which sends a `CleanUpTimedOutRequest` at the current time.
- Added a disabled example of the `timeoutCron` in the skaffold values file
- Updated skaffold values file for new postgres chart version