### PR TITLE
feat: add a queue size prometheus metric, submit-task cli command

### DIFF
--- a/cmd/submitTask.go
+++ b/cmd/submitTask.go
@@ -1,0 +1,73 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	corndogsv1alpha1 "github.com/TnLCommunity/protos-corndogs/gen/proto/go/corndogs/v1alpha1"
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
+	"google.golang.org/grpc"
+)
+
+// submitTaskCmd represents the submitTask command
+var submitTaskCmd = NewSubmitTaskCmd()
+
+func NewSubmitTaskCmd() *cobra.Command {
+	var address, port string
+	var queue, currentState, autoTargetState, payload string
+	var timeout, priority int64
+	cmd := &cobra.Command{
+		Use:   "submit-task",
+		Short: "creates a corndogs task",
+		Run: func(cmd *cobra.Command, args []string) {
+			doSubmitTask(address, port, &corndogsv1alpha1.SubmitTaskRequest{
+				Queue:           queue,
+				CurrentState:    currentState,
+				AutoTargetState: autoTargetState,
+				Timeout:         timeout,
+				Payload:         []byte(payload),
+				Priority:        priority,
+			})
+		},
+	}
+	cmd.Flags().StringVarP(&address, "address", "a", "127.0.0.1", "The address to connect to the corndogs service")
+	cmd.Flags().StringVarP(&port, "port", "p", "5080", "The port to connect to the corndogs service")
+	cmd.Flags().StringVarP(&queue, "queue", "q", "", "The queue to submit the task to")
+	cmd.Flags().StringVarP(&currentState, "current-state", "c", "", "The current state of the task")
+	cmd.Flags().StringVarP(&autoTargetState, "auto-target-state", "t", "", "The target state of the task")
+	cmd.Flags().Int64VarP(&timeout, "timeout", "o", 0, "The timeout of the task")
+	cmd.Flags().StringVarP(&payload, "payload", "l", "", "The payload of the task")
+	cmd.Flags().Int64VarP(&priority, "priority", "r", 0, "The priority of the task")
+	rootCmd.AddCommand(cmd)
+	return cmd
+}
+
+func doSubmitTask(address, port string, req *corndogsv1alpha1.SubmitTaskRequest) {
+	conn, client, err := getClient(address, port, 5*time.Second)
+	if err != nil {
+		log.Err(err).Msg("failed to get client")
+		os.Exit(1)
+	}
+	defer conn.Close()
+	resp, err := client.SubmitTask(context.Background(), req)
+	if err != nil {
+		log.Err(err).Msg("failed to submit task")
+	}
+	log.Info().Msgf("response: %v", resp)
+}
+
+func getClient(address, port string, timeout time.Duration) (*grpc.ClientConn, corndogsv1alpha1.CorndogsServiceClient, error) {
+	var err error
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	target := fmt.Sprintf("%s:%s", address, port)
+	conn, err := grpc.DialContext(ctx, target, grpc.WithInsecure())
+	for err != nil {
+		return nil, nil, err
+	}
+	corndogsClient := corndogsv1alpha1.NewCorndogsServiceClient(conn)
+	return conn, corndogsClient, nil
+}

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -3,12 +3,16 @@ package config
 import (
 	"os"
 	"strconv"
+	"time"
 )
 
 var LogLevel = GetEnvOrDefault("LOGLEVEL", "error")
 var FlushBytes = int64(GetEnvAsIntOrDefault("FLUSH_BYTES", "1000"))
 var PrometheusEnabled = GetEnvAsBoolOrDefault("PROMETHEUS_ENABLED", "false")
 var PrometheusNamespace = GetEnvOrDefault("PROMETHEUS_NAMESPACE", "corndogs")
+var PrometheusQueueSizeEnabled = GetEnvAsBoolOrDefault("PROMETHEUS_QUEUE_SIZE_ENABLED", "true")
+var PrometheusQueueSizeInterval = GetEnvAsDurationOrDefault("PROMETHEUS_QUEUE_SIZE_INTERVAL", "15s")
+var PrometheusMetricQueryTimeout = GetEnvAsDurationOrDefault("PROMETHEUS_METRIC_QUERY_TIMEOUT", "5s")
 var DefaultQueue = GetEnvOrDefault("DEFAULT_QUEUE", "default")
 var DefaultStartingState = GetEnvOrDefault("DEFAULT_STARTING_STATE", "submitted")
 var DefaultTimeout = int64(GetEnvAsIntOrDefault("DEFAULT_TIMEOUT", "0"))
@@ -47,4 +51,17 @@ func GetEnvAsBoolOrDefault(env, defaultValue string) bool {
 		panic(err)
 	}
 	return boolValue
+}
+
+func GetEnvAsDurationOrDefault(env, defaultValue string) time.Duration {
+	value := os.Getenv(env)
+	if value == "" {
+		value = defaultValue
+	}
+
+	durationValue, err := time.ParseDuration(value)
+	if err != nil {
+		panic(err)
+	}
+	return durationValue
 }

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -63,7 +63,7 @@ func StartQueueSizeMetric(interval time.Duration, queryTimeout time.Duration) {
 		for range ticker.C {
 			response, err := getQueueAndStateCounts(queryTimeout)
 			if err != nil {
-				log.Err(err).Msg("failed to get queue task counts")
+				log.Err(err).Msg("failed to get queue and state counts for metrics")
 				continue
 			}
 

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -1,18 +1,24 @@
 package metrics
 
 import (
+	"context"
 	"net/http"
+	"time"
 
 	"github.com/TnLCommunity/corndogs/server/config"
+	"github.com/TnLCommunity/corndogs/server/store"
+	corndogsv1alpha1 "github.com/TnLCommunity/protos-corndogs/gen/proto/go/corndogs/v1alpha1"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/rs/zerolog/log"
 )
 
 var TasksTotal prometheus.Counter
 var CompletedTasksTotal prometheus.Counter
 var CanceledTasksTotal prometheus.Counter
 var TimedOutTasksTotal prometheus.Counter
+var TasksInQueue *prometheus.GaugeVec
 
 func StartMetricsEndpoint() {
 	http.Handle("/metrics", promhttp.Handler())
@@ -40,4 +46,41 @@ func InitializeMetrics() {
 		Name:      "timed_out_tasks_total",
 		Help:      "The total tasks that have been timed out",
 	})
+
+	TasksInQueue = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: config.PrometheusNamespace,
+		Name:      "tasks_in_queue",
+		Help:      "The total tasks that are currently in the queue",
+	}, []string{"queue", "current_state"})
+}
+
+// StartQueueSizeMetric starts a goroutine that will periodically query the
+// database for the number of tasks in each queue and in each state, and update
+// the tasks_in_queue metric
+func StartQueueSizeMetric(interval time.Duration, queryTimeout time.Duration) {
+	go func() {
+		ticker := time.NewTicker(interval)
+		for range ticker.C {
+			response, err := getQueueAndStateCounts(queryTimeout)
+			if err != nil {
+				log.Err(err).Msg("failed to get queue task counts")
+				continue
+			}
+
+			for queue, stateCounts := range response.QueueAndStateCounts {
+				for state, count := range stateCounts.StateCounts {
+					TasksInQueue.With(prometheus.Labels{
+						"queue":         queue,
+						"current_state": state,
+					}).Set(float64(count))
+				}
+			}
+		}
+	}()
+}
+
+func getQueueAndStateCounts(timeout time.Duration) (*corndogsv1alpha1.GetQueueAndStateCountsResponse, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	return store.AppStore.GetQueueAndStateCounts(ctx, &corndogsv1alpha1.GetQueueAndStateCountsRequest{})
 }

--- a/server/server.go
+++ b/server/server.go
@@ -87,6 +87,9 @@ func run() error {
 		grpc_prometheus.Register(server)
 		metrics.StartMetricsEndpoint()
 		metrics.InitializeMetrics()
+		if config.PrometheusQueueSizeEnabled {
+			metrics.StartQueueSizeMetric(config.PrometheusQueueSizeInterval, config.PrometheusMetricQueryTimeout)
+		}
 	}
 	// register health service (used in k8s health checks)
 	healthService := implementations.NewHealthChecker()


### PR DESCRIPTION
- feat: add a queue size prometheus metric

add configurations for this metric, with the ability to disable it if
it's unwanted as it will incur database load.

start a background go routine that will periodically query the database
to set the queue size metric.

- feat: add a submit-task command

this makes it easier to interact with corndogs via the cli, similar to
the way the timeout functionality currently works.
